### PR TITLE
feat: Improve test coverage annotation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Annotate Coverage Action
-        uses: drew2a/annotate-coverage-action@v1
+        id: annotate
+        uses: ./
         with:
           json_path: "tests/test_coverage.json"
+
+      - name: Compare generated output with expected
+        run: |
+          echo "${{ steps.annotate.outputs.annotations }}" > generated_output.txt
+          diff -u tests/expected_output.txt generated_output.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-02-19
+
+Improve test coverage annotation:
+
+* The CI workflow has been updated to use a local action for annotating test coverage. The annotations are now collected
+  into a single string and written to an output file, which is then compared with the expected output.
+
 ## [0.1.0] - 2025-02-19
 
 ### Added
+
 - Initial project setup with core files:
-  - GitHub Actions workflow configuration (ci.yml)
-  - Docker configuration (Dockerfile)
-  - Action configuration (action.yml)
-  - Main script (annotate_coverage.py)
-  - Test coverage data (tests/test_coverage.json)
-  - Project configuration files (.gitignore, IDE settings)
-  - Documentation (README.md, LICENSE)
-  - This CHANGELOG.md
+    - GitHub Actions workflow configuration (ci.yml)
+    - Docker configuration (Dockerfile)
+    - Action configuration (action.yml)
+    - Main script (annotate_coverage.py)
+    - Test coverage data (tests/test_coverage.json)
+    - Project configuration files (.gitignore, IDE settings)
+    - Documentation (README.md, LICENSE)
+    - This CHANGELOG.md

--- a/annotate_coverage.py
+++ b/annotate_coverage.py
@@ -20,6 +20,7 @@ Example output:
 """
 
 import json
+import os
 import sys
 
 if len(sys.argv) != 2:
@@ -36,13 +37,15 @@ annotations = []
 
 for file_path, stats in src_stats.items():
     violations = stats.get("violations", [])
-
     for line, _ in violations:
-        message = (
-            f"Line {line} is not covered by tests. Consider adding test cases to improve coverage."
-        )
+        message = f"Line {line} is not covered by tests. Consider adding test cases to improve coverage."
+        annotation = f"::warning file={file_path},line={line}::{message}"
+        annotations.append(annotation)
 
-        annotation = (
-            f"::warning file={file_path},line={line}::{message}"
-        )
-        print(annotation)
+# Combine all annotations into a single string
+output = "\n".join(annotations)
+print(output)
+
+# Set the output for the GitHub Actions step (using the recommended GITHUB_OUTPUT method)
+with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+    fh.write(f"annotations<<EOF\n{output}\nEOF\n")

--- a/tests/expected_output.txt
+++ b/tests/expected_output.txt
@@ -1,0 +1,3 @@
+::warning file=annotate_coverage.py,line=1::Line 1 is not covered by tests. Consider adding test cases to improve coverage.
+::warning file=annotate_coverage.py,line=2::Line 2 is not covered by tests. Consider adding test cases to improve coverage.
+::warning file=annotate_coverage.py,line=3::Line 3 is not covered by tests. Consider adding test cases to improve coverage.

--- a/tests/test_coverage.json
+++ b/tests/test_coverage.json
@@ -2,27 +2,27 @@
   "report_name": "XML",
   "diff_name": "origin/main...HEAD, staged and unstaged changes",
   "src_stats": {
-    "file.py": {
+    "annotate_coverage.py": {
       "percent_covered": 25.0,
       "violation_lines": [
-        24,
-        25,
-        26
+        1,
+        2,
+        3
       ],
       "covered_lines": [
-        23
+        4
       ],
       "violations": [
         [
-          24,
+          1,
           null
         ],
         [
-          25,
+          2,
           null
         ],
         [
-          26,
+          3,
           null
         ]
       ]


### PR DESCRIPTION
The CI workflow has been updated to use a local action for annotating test coverage. The annotations are now collected into a single string and written to an output file, which is then compared with the expected output.