### PR TITLE
feat: Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build and Test](https://github.com/drew2a/annotate-coverage-action/actions/workflows/ci.yml/badge.svg)](https://github.com/drew2a/annotate-coverage-action/actions/workflows/ci.yml)
+
+
 # Annotate Coverage Action
 
 This GitHub Action adds annotations for uncovered lines in PRs based on a coverage report.


### PR DESCRIPTION
A Continuous Integration (CI) status badge has been added to the README file. This badge will provide a visual indication of the build and test status, enhancing transparency for project contributors and users.