### PR TITLE
feat: Add Ruff workflow for PRs

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -1,0 +1,20 @@
+name: Ruff
+on: [ pull_request ]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: pipx install ruff
+
+      - name: Get changed Python files
+        id: changed-py-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            **/*.py
+
+      - name: Run Ruff
+        if: steps.changed-py-files.outputs.any_changed == 'true'
+        run: ruff check --output-format=github ${{ steps.changed-py-files.outputs.all_changed_files }} --force-exclude


### PR DESCRIPTION
A new GitHub Actions workflow has been added to run the Ruff tool on Python files in pull requests. This will ensure that any changes made to Python files adhere to coding standards and best practices before they are merged into the main codebase. The workflow is set up to only run when there are changes detected in Python files, optimizing resource usage.
